### PR TITLE
fix(initialization): Fix when no node is present during initialization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,28 @@ repos:
     hooks:
       - id: commitizen
 
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.29.7
+    hooks:
+      - id: typos
+        name: "🔍 Code Quality · Check for typos"
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.22.1
+    hooks:
+      - id: gitleaks
+        name: "🔒 Security · Detect hardcoded secrets"
+
+  - repo: https://github.com/mrtazz/checkmake.git
+    rev: 0.2.2
+    hooks:
+      - id: checkmake
+        name: "🐮 Makefile · Lint Makefile"
+
   - repo: local
     hooks:
       - id: run-make-test
-        name: Run make test
+        name: "🧪 Tests ·  Run tests"
         entry: make -C cli test
         language: system
         pass_filenames: false
-        stages: [pre-push]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ installed. Change directory to the cli folder:
 cd cli
 ```
 
-Then to run a CLI command run:
+To call a CLI command, run:
 
 ```bash
 go run main.go <command>

--- a/cli/cmd/setup.go
+++ b/cli/cmd/setup.go
@@ -82,7 +82,7 @@ func setupCommand(helperService interfaces.HelperServiceInterface, dependencySer
 
 	configExists := configService.CheckForTalosConfigs(helperService)
 	if !configExists && !createControlPlane {
-		return fmt.Errorf("No config files found while trying to enroll new node in exsting cluster, please create your first node first")
+		return fmt.Errorf("No config files found while trying to enroll new node in existing cluster, please create your first node first")
 	}
 
 	answer, err = uiService.CreateSelect("What type of device are you setting up?", []string{"Intel NUC", "Raspberry Pi 4 (or older)"})
@@ -147,8 +147,13 @@ func setupCommand(helperService interfaces.HelperServiceInterface, dependencySer
 	logger.Infof("Found %d Talos device(s)", len(ips))
 
 	if len(ips) > 1 {
-		return fmt.Errorf("More than one node found, please make sure there is only 1 Talos node in maintanance mode.")
+		return fmt.Errorf("More than one node found, please make sure there is only 1 Talos node in maintenance mode.")
 	}
+
+	if len(ips) == 0 {
+		return fmt.Errorf("No node found, please make sure there is only 1 Talos node in maintenance mode.")
+	}
+
 	originalIp := ips[0]
 
 	///////////////////////////////////////////////////////////////////////////////// QUESTIONS ///////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/cli/cmd/setup_test.go
+++ b/cli/cmd/setup_test.go
@@ -136,6 +136,24 @@ func Test_setupCommand_Succeeds_GeneratesAwsConfig(t *testing.T) {
 	configService.AssertNumberOfCalls(t, "UpdateBbeClusterName", 1)
 }
 
+func Test_setupCommand_Fails_WithNoNodeFound(t *testing.T) {
+	helperService, dependencyService, talosService, ipFinderService, uiService, configService, imageService, gatewayIp, nodeIp, chosenIp := initSetupTests()
+
+	ipFinderService.On("LocateDevice", helperService, talosService, gatewayIp).Return([]string{}, nil)
+
+	mockSuccessfulSetupFlow(helperService, dependencyService, talosService, ipFinderService, uiService, configService, imageService, gatewayIp, nodeIp, chosenIp, true)
+
+	err := setupCommand(helperService, dependencyService, talosService, ipFinderService, uiService, configService, imageService)
+
+	assert.NotNil(t, err)
+	helperService.AssertNumberOfCalls(t, "IsValidIp", 0)
+	imageService.AssertNumberOfCalls(t, "CreateImage", 1)
+	talosService.AssertNumberOfCalls(t, "GetDisks", 0)
+	configService.AssertNumberOfCalls(t, "GenerateBbeConfig", 0)
+	configService.AssertNumberOfCalls(t, "SyncConfigsWithAws", 0)
+	configService.AssertNumberOfCalls(t, "UpdateBbeClusterName", 0)
+}
+
 func Test_setupCommand_Fails_WithMoreThanOneNodeFound(t *testing.T) {
 	helperService, dependencyService, talosService, ipFinderService, uiService, configService, imageService, gatewayIp, nodeIp, chosenIp := initSetupTests()
 


### PR DESCRIPTION
An out of boundaries error was being thrown, fail gracefully instead.