### PR TITLE
fix(packages): Typo on helm install

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,13 +5,24 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch Package",
+            "name": "Run: Setup",
             "type": "go",
             "request": "launch",
             "mode": "debug",
             "program": "${workspaceRoot}/cli",
             "args": [
                 "setup"
+            ],
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "Run: Install",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceRoot}/cli",
+            "args": [
+                "install"
             ],
             "console": "integratedTerminal"
         }

--- a/cli/services/package_service/package_service.go
+++ b/cli/services/package_service/package_service.go
@@ -53,7 +53,7 @@ func (packageService PackageService) InstallPackage(pkg models.Package) error {
 				return fmt.Errorf("failed to add helm repository %s: %w", p.PackageRepository.Name, err)
 			}
 
-			cmd = execCommand("helm", "sinstall", pkg.Name, fmt.Sprintf("%s/%s", p.PackageRepository.Name, p.HelmChart),
+			cmd = execCommand("helm", "install", pkg.Name, fmt.Sprintf("%s/%s", p.PackageRepository.Name, p.HelmChart),
 				"--version", p.HelmChartVersion,
 				"--namespace", pkg.Name,
 				"--create-namespace")


### PR DESCRIPTION
- On package installation there was a typo on the command 'install'
- Added debug for `install` command in vscode