### PR TITLE
fix: make sure to always use bbe cluster context

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -56,15 +56,15 @@ func installCommand(helperService interfaces.HelperServiceInterface, uiService i
 
 	packagesToInstall, packagesToUninstall := diffPackages(allPackages, chosenPackages)
 
-	updatedBbeConfig := &models.BbeConfig{}
+	updatedBbeConfig := *bbeConfig
 	updatedBbeConfig.Bbe.Packages = bbeConfig.Bbe.Packages
 
-	err = uninstallPackages(helperService, configService, packageService, *updatedBbeConfig, packagesToUninstall)
+	err = uninstallPackages(helperService, configService, packageService, updatedBbeConfig, packagesToUninstall)
 	if err != nil {
 		return fmt.Errorf("Failed to uninstall packages: %w", err)
 	}
 
-	err = installPackages(helperService, configService, packageService, *updatedBbeConfig, packagesToInstall)
+	err = installPackages(helperService, configService, packageService, updatedBbeConfig, packagesToInstall)
 	if err != nil {
 		return fmt.Errorf("Failed to install packages: %w", err)
 	}
@@ -107,7 +107,7 @@ func uninstallPackages(helperService interfaces.HelperServiceInterface, configSe
 	for _, pkg := range uninstalledPackages {
 		for i, existingPkg := range updatedBbeConfig.Bbe.Packages {
 			if existingPkg.Name == pkg.Name {
-				err := packageService.UninstallPackage(pkg)
+				err := packageService.UninstallPackage(pkg, updatedBbeConfig)
 				if err != nil {
 					logger.Error("Failed to uninstall package", err)
 					continue
@@ -127,7 +127,7 @@ func uninstallPackages(helperService interfaces.HelperServiceInterface, configSe
 
 func installPackages(helperService interfaces.HelperServiceInterface, configService interfaces.ConfigServiceInterface, packageService interfaces.PackageServiceInterface, updatedBbeConfig models.BbeConfig, installedPackages []models.Package) error {
 	for _, pkg := range installedPackages {
-		err := packageService.InstallPackage(pkg)
+		err := packageService.InstallPackage(pkg, updatedBbeConfig)
 		if err != nil {
 			return fmt.Errorf("Failed to install package: %w", err)
 		}

--- a/cli/interfaces/packages_service.go
+++ b/cli/interfaces/packages_service.go
@@ -4,6 +4,6 @@ import "github.com/Brains-Beyond-Expectations/bbe-quest/models"
 
 type PackageServiceInterface interface {
 	GetAll() []models.Package
-	InstallPackage(pkg models.Package) error
-	UninstallPackage(pkg models.Package) error
+	InstallPackage(pkg models.Package, bbeConfig models.BbeConfig) error
+	UninstallPackage(pkg models.Package, bbeConfig models.BbeConfig) error
 }

--- a/cli/mocks/package_service_mock.go
+++ b/cli/mocks/package_service_mock.go
@@ -14,12 +14,12 @@ func (m *MockPackageService) GetAll() []models.Package {
 	return args.Get(0).([]models.Package)
 }
 
-func (m *MockPackageService) InstallPackage(pkg models.Package) error {
+func (m *MockPackageService) InstallPackage(pkg models.Package, bbeConfig models.BbeConfig) error {
 	args := m.Called(pkg)
 	return args.Error(0)
 }
 
-func (m *MockPackageService) UninstallPackage(pkg models.Package) error {
+func (m *MockPackageService) UninstallPackage(pkg models.Package, bbeConfig models.BbeConfig) error {
 	args := m.Called(pkg)
 	return args.Error(0)
 }

--- a/cli/models/bbe_config.go
+++ b/cli/models/bbe_config.go
@@ -12,6 +12,6 @@ type BbeConfig struct {
 				BucketName string `yaml:"bucket_name,omitempty"`
 			} `yaml:"aws,omitempty"`
 		} `yaml:"storage,omitempty"`
-		Packages []Package `yaml:"packages,omitempty"`
+		Packages []Package `yaml:"packages"`
 	} `yaml:"bbe,omitempty"`
 }

--- a/cli/models/bbe_config.go
+++ b/cli/models/bbe_config.go
@@ -3,7 +3,8 @@ package models
 type BbeConfig struct {
 	Bbe struct {
 		Cluster struct {
-			Name string `yaml:"name,omitempty"`
+			Name    string `yaml:"name,omitempty"`
+			Context string `yaml:"context,omitempty"`
 		} `yaml:"cluster,omitempty"`
 		Storage struct {
 			Type string `yaml:"type,omitempty"` // "local" or "aws"

--- a/cli/models/package.go
+++ b/cli/models/package.go
@@ -1,6 +1,6 @@
 package models
 
 type Package struct {
-	Name    string `yaml:"name"`
-	Version string `yaml:"version"`
+	Name    string `yaml:"name,omitempty"`
+	Version string `yaml:"version,omitempty"`
 }

--- a/cli/services/config_service/config_service.go
+++ b/cli/services/config_service/config_service.go
@@ -75,6 +75,7 @@ func (config ConfigService) UpdateBbeClusterName(helperService interfaces.Helper
 	}
 
 	bbeConfig.Bbe.Cluster.Name = clusterName
+	bbeConfig.Bbe.Cluster.Context = fmt.Sprintf("admin@%s", clusterName)
 
 	return config.writeBbeConfig(helperService, bbeConfig)
 }

--- a/cli/services/config_service/config_service.go
+++ b/cli/services/config_service/config_service.go
@@ -116,6 +116,15 @@ func (config ConfigService) UpdateBbePackages(helperService interfaces.HelperSer
 func (config ConfigService) writeBbeConfig(helperService interfaces.HelperServiceInterface, bbeConfig *models.BbeConfig) error {
 	fileLocation := fmt.Sprintf("%s/%s", helperService.GetConfigDir(), constants.BbeConfigFile)
 
+	// Filter out any empty packages to avoid writing them to the config file
+	var filteredPackages []models.Package
+	for _, pkg := range bbeConfig.Bbe.Packages {
+		if pkg.Name != "" || pkg.Version != "" {
+			filteredPackages = append(filteredPackages, pkg)
+		}
+	}
+	bbeConfig.Bbe.Packages = filteredPackages
+
 	yamlFile, err := yaml.Marshal(bbeConfig)
 	if err != nil {
 		return err

--- a/cli/services/package_service/package_service.go
+++ b/cli/services/package_service/package_service.go
@@ -45,7 +45,7 @@ func (packageService PackageService) GetAll() []models.Package {
 	return packageList
 }
 
-func (packageService PackageService) InstallPackage(pkg models.Package) error {
+func (packageService PackageService) InstallPackage(pkg models.Package, bbeConfig models.BbeConfig) error {
 	for _, p := range packages {
 		if p.Package.Name == pkg.Name {
 			cmd := execCommand("helm", "repo", "add", p.PackageRepository.Name, p.PackageRepository.RepositoryUrl)
@@ -56,7 +56,8 @@ func (packageService PackageService) InstallPackage(pkg models.Package) error {
 			cmd = execCommand("helm", "install", pkg.Name, fmt.Sprintf("%s/%s", p.PackageRepository.Name, p.HelmChart),
 				"--version", p.HelmChartVersion,
 				"--namespace", pkg.Name,
-				"--create-namespace")
+				"--create-namespace",
+				"--kube-context", bbeConfig.Bbe.Cluster.Context)
 			if err := cmd.Run(); err != nil {
 				return fmt.Errorf("failed to install helm package %s: %w", pkg.Name, err)
 			}
@@ -67,11 +68,12 @@ func (packageService PackageService) InstallPackage(pkg models.Package) error {
 	return fmt.Errorf("package %s not found", pkg.Name)
 }
 
-func (packageService PackageService) UninstallPackage(pkg models.Package) error {
+func (packageService PackageService) UninstallPackage(pkg models.Package, bbeConfig models.BbeConfig) error {
 	for _, p := range packages {
 		if p.Package.Name == pkg.Name {
 			cmd := execCommand("helm", "uninstall", pkg.Name,
-				"--namespace", pkg.Name)
+				"--namespace", pkg.Name,
+				"--kube-context", bbeConfig.Bbe.Cluster.Context)
 			if err := cmd.Run(); err != nil {
 				return fmt.Errorf("failed to uninstall helm package %s: %w", pkg.Name, err)
 			}

--- a/cli/services/package_service/package_service_test.go
+++ b/cli/services/package_service/package_service_test.go
@@ -26,7 +26,9 @@ func Test_InstallPackage_Fails_WhenPackageNotFound(t *testing.T) {
 
 	packagesService := PackageService{}
 
-	err := packagesService.InstallPackage(models.Package{Name: "not-a-real-package", Version: "0.1.3"})
+	bbeConfig := models.BbeConfig{}
+	bbeConfig.Bbe.Cluster.Context = "test-context"
+	err := packagesService.InstallPackage(models.Package{Name: "not-a-real-package", Version: "0.1.3"}, bbeConfig)
 
 	// Assert an error occurred
 	assert.Error(t, err)
@@ -41,7 +43,9 @@ func Test_InstallPackage_Fails_WhenHelmRepositoryNotFound(t *testing.T) {
 
 	packagesService := PackageService{}
 
-	err := packagesService.InstallPackage(models.Package{Name: "blocky", Version: "0.1.3"})
+	bbeConfig := models.BbeConfig{}
+	bbeConfig.Bbe.Cluster.Context = "test-context"
+	err := packagesService.InstallPackage(models.Package{Name: "blocky", Version: "0.1.3"}, bbeConfig)
 
 	// Assert an error occurred
 	assert.Error(t, err)
@@ -60,7 +64,9 @@ func Test_InstallPackage_Fails_WhenHelmInstallFails(t *testing.T) {
 
 	packagesService := PackageService{}
 
-	err := packagesService.InstallPackage(models.Package{Name: "blocky", Version: "0.1.3"})
+	bbeConfig := models.BbeConfig{}
+	bbeConfig.Bbe.Cluster.Context = "test-context"
+	err := packagesService.InstallPackage(models.Package{Name: "blocky", Version: "0.1.3"}, bbeConfig)
 
 	// Assert an error occurred
 	assert.Error(t, err)
@@ -75,7 +81,9 @@ func Test_InstallPackage_Succeeds(t *testing.T) {
 
 	packagesService := PackageService{}
 
-	err := packagesService.InstallPackage(models.Package{Name: "blocky", Version: "0.1.3"})
+	bbeConfig := models.BbeConfig{}
+	bbeConfig.Bbe.Cluster.Context = "test-context"
+	err := packagesService.InstallPackage(models.Package{Name: "blocky", Version: "0.1.3"}, bbeConfig)
 
 	// Assert an error occurred
 	assert.NoError(t, err)
@@ -85,7 +93,9 @@ func Test_UninstallPackage_Fails_WhenPackageNotFound(t *testing.T) {
 	packageName := "not-a-real-package"
 	packagesService := PackageService{}
 
-	err := packagesService.UninstallPackage(models.Package{Name: packageName, Version: "0.1.3"})
+	bbeConfig := models.BbeConfig{}
+	bbeConfig.Bbe.Cluster.Context = "test-context"
+	err := packagesService.UninstallPackage(models.Package{Name: packageName, Version: "0.1.3"}, bbeConfig)
 
 	// Assert an error occurred
 	assert.Error(t, err)
@@ -100,7 +110,9 @@ func Test_UninstallPackage_Fails_WhenHelmFails(t *testing.T) {
 
 	packagesService := PackageService{}
 
-	err := packagesService.UninstallPackage(models.Package{Name: "blocky", Version: "0.1.3"})
+	bbeConfig := models.BbeConfig{}
+	bbeConfig.Bbe.Cluster.Context = "test-context"
+	err := packagesService.UninstallPackage(models.Package{Name: "blocky", Version: "0.1.3"}, bbeConfig)
 
 	// Assert an error occurred
 	assert.Error(t, err)
@@ -115,7 +127,9 @@ func Test_UninstallPackage_Succeeds(t *testing.T) {
 
 	packagesService := PackageService{}
 
-	err := packagesService.UninstallPackage(models.Package{Name: "blocky", Version: "0.1.3"})
+	bbeConfig := models.BbeConfig{}
+	bbeConfig.Bbe.Cluster.Context = "test-context"
+	err := packagesService.UninstallPackage(models.Package{Name: "blocky", Version: "0.1.3"}, bbeConfig)
 
 	// Assert an error occurred
 	assert.NoError(t, err)


### PR DESCRIPTION
Ensures we will always use the correct context when performing helm commands by saving the context in the `bbe.yaml` config file. Adds a new field at bbe.cluster.context; hence a breaking change, but I think we can get away with that at this point.
Additionally makes sure that empty packages are not written to the bbe config