### PR TITLE
feat: upgrade packages

### DIFF
--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -64,11 +64,7 @@ func upgradeCommand(helperService interfaces.HelperServiceInterface, uiService i
 							return err
 						}
 
-						if result == "Yes" {
-							upgrade = true
-						} else {
-							upgrade = false
-						}
+						upgrade = result == "Yes"
 					}
 					if upgrade {
 						err := packageService.UpgradePackage(pkg, *bbeConfig)

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Brains-Beyond-Expectations/bbe-quest/interfaces"
+	"github.com/Brains-Beyond-Expectations/bbe-quest/misc/logger"
+	"github.com/Brains-Beyond-Expectations/bbe-quest/services/config_service"
+	"github.com/Brains-Beyond-Expectations/bbe-quest/services/helper_service"
+	"github.com/Brains-Beyond-Expectations/bbe-quest/services/package_service"
+	"github.com/Brains-Beyond-Expectations/bbe-quest/services/ui_service"
+	"github.com/spf13/cobra"
+)
+
+var upgradeCmd = &cobra.Command{
+	Use:     "upgrade",
+	Aliases: []string{"u"},
+	Short:   "Upgrade BBE packages",
+	Args:    cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) { // coverage-ignore
+		helperService := helper_service.HelperService{}
+		uiService := ui_service.UiService{}
+		configService := config_service.ConfigService{}
+		packageService := package_service.PackageService{}
+
+		uninteractive, _ := cmd.Flags().GetBool("yes")
+
+		err := upgradeCommand(helperService, uiService, configService, packageService, uninteractive)
+		if err != nil {
+			logger.Error("", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func upgradeCommand(helperService interfaces.HelperServiceInterface, uiService interfaces.UiServiceInterface, configService interfaces.ConfigServiceInterface, packageService interfaces.PackageServiceInterface, uninteractive bool) error {
+	bbeConfig, err := configService.GetBbeConfig(helperService)
+	if err != nil || bbeConfig.Bbe.Cluster.Name == "" {
+		logger.Info("No BBE cluster found, please run 'bbe setup' to create your cluster")
+		return nil
+	}
+
+	installedPackages := bbeConfig.Bbe.Packages
+	allPackages := packageService.GetAll()
+
+	defer func() {
+		err := configService.UpdateBbePackages(helperService, installedPackages)
+		if err != nil {
+			logger.Error("Failed to update BBE packages", err)
+		}
+	}()
+
+	// Go through our currently installed packages and see if a newer version is available
+	for i, installedPackage := range installedPackages {
+		logger.Info(fmt.Sprintf("Checking for newer version of package %s...", installedPackage.Name))
+		for _, pkg := range allPackages {
+			if installedPackage.Name == pkg.Name {
+				if installedPackage.Version != pkg.Version {
+					upgrade := uninteractive
+					if !uninteractive {
+						result, err := uiService.CreateSelect(fmt.Sprintf("Package %s has newer version %s available. Do you want to upgrade?", pkg.Name, pkg.Version), []string{"Yes", "No"})
+						if err != nil {
+							return err
+						}
+
+						if result == "Yes" {
+							upgrade = true
+						} else {
+							upgrade = false
+						}
+					}
+					if upgrade {
+						err := packageService.UpgradePackage(pkg, *bbeConfig)
+						if err != nil {
+							return err
+						}
+						installedPackages[i].Version = pkg.Version
+					}
+				}
+				break
+			}
+		}
+	}
+
+	logger.Info("All packages checked")
+
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(upgradeCmd)
+
+	upgradeCmd.PersistentFlags().BoolP("yes", "y", false, "Automatically accept yes/no questions without input.")
+}

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Brains-Beyond-Expectations/bbe-quest/mocks"
+	"github.com/Brains-Beyond-Expectations/bbe-quest/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func Test_upgradeCommand_Succeeds_WithNothingToDo(t *testing.T) {
+	helperService, uiService, configService, packageService := initUpgradeCommand()
+
+	mockSuccessfulUpgradeFlow(helperService, uiService, configService, packageService)
+
+	err := upgradeCommand(helperService, uiService, configService, packageService, false)
+
+	assert.Nil(t, err)
+	configService.AssertNumberOfCalls(t, "GetBbeConfig", 1)
+	packageService.AssertNumberOfCalls(t, "GetAll", 1)
+	uiService.AssertNumberOfCalls(t, "CreateSelect", 0)
+	packageService.AssertNumberOfCalls(t, "UpgradePackage", 0)
+	configService.AssertCalled(t, "UpdateBbePackages", mock.Anything, []models.Package{
+		{
+			Name:    "package_one",
+			Version: "2.0.0",
+		},
+	})
+}
+
+func Test_upgradeCommand_Succeeds_WithInteractiveUpgrade(t *testing.T) {
+	helperService, uiService, configService, packageService := initUpgradeCommand()
+
+	uiService.On("CreateSelect", mock.Anything, mock.Anything).Return("Yes", nil).Once()
+	uiService.On("CreateSelect", mock.Anything, mock.Anything).Return("No", nil).Once()
+	bbeConfig := &models.BbeConfig{}
+	bbeConfig.Bbe.Cluster.Name = "test"
+	bbeConfig.Bbe.Packages = []models.Package{
+		{
+			Name:    "package_one",
+			Version: "1.0.0",
+		},
+		{
+			Name:    "package_two",
+			Version: "1.0.0",
+		},
+	}
+	configService.On("GetBbeConfig", mock.Anything).Return(bbeConfig, nil)
+
+	mockSuccessfulUpgradeFlow(helperService, uiService, configService, packageService)
+
+	err := upgradeCommand(helperService, uiService, configService, packageService, false)
+
+	assert.Nil(t, err)
+	configService.AssertNumberOfCalls(t, "GetBbeConfig", 1)
+	packageService.AssertNumberOfCalls(t, "GetAll", 1)
+	uiService.AssertNumberOfCalls(t, "CreateSelect", 2)
+	packageService.AssertNumberOfCalls(t, "UpgradePackage", 1)
+	configService.AssertCalled(t, "UpdateBbePackages", mock.Anything, []models.Package{
+		{
+			Name:    "package_one",
+			Version: "2.0.0",
+		},
+		{
+			Name:    "package_two",
+			Version: "1.0.0",
+		},
+	})
+}
+
+func Test_upgradeCommand_Succeeds_WithNonInteractiveUpgrade(t *testing.T) {
+	helperService, uiService, configService, packageService := initUpgradeCommand()
+
+	bbeConfig := &models.BbeConfig{}
+	bbeConfig.Bbe.Cluster.Name = "test"
+	bbeConfig.Bbe.Packages = []models.Package{
+		{
+			Name:    "package_one",
+			Version: "1.0.0",
+		},
+		{
+			Name:    "package_two",
+			Version: "1.0.0",
+		},
+	}
+	configService.On("GetBbeConfig", mock.Anything).Return(bbeConfig, nil)
+
+	mockSuccessfulUpgradeFlow(helperService, uiService, configService, packageService)
+
+	err := upgradeCommand(helperService, uiService, configService, packageService, true)
+
+	assert.Nil(t, err)
+	configService.AssertNumberOfCalls(t, "GetBbeConfig", 1)
+	packageService.AssertNumberOfCalls(t, "GetAll", 1)
+	uiService.AssertNumberOfCalls(t, "CreateSelect", 0)
+	packageService.AssertNumberOfCalls(t, "UpgradePackage", 2)
+	configService.AssertCalled(t, "UpdateBbePackages", mock.Anything, []models.Package{
+		{
+			Name:    "package_one",
+			Version: "2.0.0",
+		},
+		{
+			Name:    "package_two",
+			Version: "3.0.0",
+		},
+	})
+}
+
+func Test_upgradeCommand_Fails_Prtial_UpdatesBbeConfig(t *testing.T) {
+	helperService, uiService, configService, packageService := initUpgradeCommand()
+
+	bbeConfig := &models.BbeConfig{}
+	bbeConfig.Bbe.Cluster.Name = "test"
+	bbeConfig.Bbe.Packages = []models.Package{
+		{
+			Name:    "package_one",
+			Version: "1.0.0",
+		},
+		{
+			Name:    "package_two",
+			Version: "1.0.0",
+		},
+	}
+	configService.On("GetBbeConfig", mock.Anything).Return(bbeConfig, nil)
+
+	packageService.On("UpgradePackage", mock.Anything).Return(nil).Once()
+	packageService.On("UpgradePackage", mock.Anything).Return(errors.New("test error")).Once()
+
+	mockSuccessfulUpgradeFlow(helperService, uiService, configService, packageService)
+
+	err := upgradeCommand(helperService, uiService, configService, packageService, true)
+
+	assert.NotNil(t, err)
+	configService.AssertNumberOfCalls(t, "GetBbeConfig", 1)
+	packageService.AssertNumberOfCalls(t, "GetAll", 1)
+	uiService.AssertNumberOfCalls(t, "CreateSelect", 0)
+	packageService.AssertNumberOfCalls(t, "UpgradePackage", 2)
+	configService.AssertCalled(t, "UpdateBbePackages", mock.Anything, []models.Package{
+		{
+			Name:    "package_one",
+			Version: "2.0.0",
+		},
+		{
+			Name:    "package_two",
+			Version: "1.0.0",
+		},
+	})
+}
+
+func initUpgradeCommand() (*mocks.MockHelperService, *mocks.MockUiService, *mocks.MockConfigService, *mocks.MockPackageService) {
+	helperService := &mocks.MockHelperService{}
+	uiService := &mocks.MockUiService{}
+	configService := &mocks.MockConfigService{}
+	packageService := &mocks.MockPackageService{}
+
+	return helperService, uiService, configService, packageService
+}
+
+func mockSuccessfulUpgradeFlow(_ *mocks.MockHelperService, uiService *mocks.MockUiService, configService *mocks.MockConfigService, packageService *mocks.MockPackageService) {
+	bbeConfig := &models.BbeConfig{}
+	bbeConfig.Bbe.Cluster.Name = "test"
+	bbeConfig.Bbe.Packages = []models.Package{
+		{
+			Name:    "package_one",
+			Version: "2.0.0",
+		},
+	}
+	configService.On("GetBbeConfig", mock.Anything).Return(bbeConfig, nil)
+	configService.On("UpdateBbePackages", mock.Anything, mock.Anything).Return(nil)
+
+	packageService.On("GetAll").Return([]models.Package{
+		{
+			Name:    "package_one",
+			Version: "2.0.0",
+		},
+		{
+			Name:    "package_two",
+			Version: "3.0.0",
+		},
+	})
+	packageService.On("UpgradePackage", mock.Anything).Return(nil)
+}

--- a/cli/interfaces/packages_service.go
+++ b/cli/interfaces/packages_service.go
@@ -5,5 +5,6 @@ import "github.com/Brains-Beyond-Expectations/bbe-quest/models"
 type PackageServiceInterface interface {
 	GetAll() []models.Package
 	InstallPackage(pkg models.Package, bbeConfig models.BbeConfig) error
+	UpgradePackage(pkg models.Package, bbeConfig models.BbeConfig) error
 	UninstallPackage(pkg models.Package, bbeConfig models.BbeConfig) error
 }

--- a/cli/mocks/package_service_mock.go
+++ b/cli/mocks/package_service_mock.go
@@ -19,6 +19,11 @@ func (m *MockPackageService) InstallPackage(pkg models.Package, bbeConfig models
 	return args.Error(0)
 }
 
+func (m *MockPackageService) UpgradePackage(pkg models.Package, bbeConfig models.BbeConfig) error {
+	args := m.Called(pkg)
+	return args.Error(0)
+}
+
 func (m *MockPackageService) UninstallPackage(pkg models.Package, bbeConfig models.BbeConfig) error {
 	args := m.Called(pkg)
 	return args.Error(0)


### PR DESCRIPTION
Add the `bbe upgrade` command which can be used to interactively upgrade installed packages. Also allows the use of the `--yes` or `-y` flags to uninteractively accept all upgrades.

Solves #16 