### PR TITLE
chore: run tests on main workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Run tests with coverage
+        run: |
+          cd cli
+          make test
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Release Drafter
         uses: release-drafter/release-drafter@v6
         id: release-drafter


### PR DESCRIPTION
We should run tests and collect code coverage on the main branch as well