### PR TITLE
fix: remove binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ cover.out
 __debug_*
 coverage.out
 *.code-workspace
+
+# Binary
+cli/cli


### PR DESCRIPTION
This PR removes the binary that was accidentally commited and ensures it can't happen again by adding it to the .gitignore